### PR TITLE
revise to correct syntax

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module ChatSpace
       g.coffee  false
       g.helper  false
       g.test_framework  false
+    end
   end
 end


### PR DESCRIPTION
#WHAT
rails g migration時に不要なファイルを生成しないためのファイルにて、文法エラーを訂正

#WHY
コマンド実行のため